### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/Utils/Common.py
+++ b/src/Utils/Common.py
@@ -1,6 +1,7 @@
 import numpy as np
 import multiprocessing as mp
 
+
 def hamming_distance_preset_length(string1, string2, barcode_length=35, cutoff=1):
     """
     Computes the hamming distance between two strings up until the string_distance is greater than cutoff and returns that value.


### PR DESCRIPTION
There appear to be some python formatting errors in 4ede539fa9a07a3d97df4fbd0170dd34994f049f. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.