### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/BartenderReport.py
+++ b/src/BartenderReport.py
@@ -67,7 +67,7 @@ def main():
     if not os.path.exists(args.run_dir):
         raise ValueError(f"run_dir {args.run_dir} does not exist")
 
-    build_report_dir = pjoin(os.path.dirname(os.path.realpath(__file__)), 'Reports')
+    build_report_dir = pjoin(os.path.dirname(os.path.realpath(__file__)), "Reports")
 
     print(build_report_dir)
 


### PR DESCRIPTION
There appear to be some python formatting errors in 02c59c99005eca89143711790dc1a720793046db. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.