### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/BartenderReport.py
+++ b/src/BartenderReport.py
@@ -17,7 +17,7 @@ def parse_arguments():
         action="store_true",
         default=False,
         help="Make experimental summary table [False]",
-    )    
+    )
     parser.add_argument(
         "--experimental_report",
         action="store_true",
@@ -113,9 +113,8 @@ def main():
         report_table.write_report_table_type_1_to_excel()
 
     if args.experimental_summary_table:
-        
         report_table = ReportTable(setup_manager=SetupManager(work_dir=args.run_dir))
-        
+
         report_table.proportion_and_count_summary()
 
         report_table.write_proportion_and_count_summary()

--- a/src/Utils/Common.py
+++ b/src/Utils/Common.py
@@ -10,6 +10,7 @@ def find_subtring_match(query, patterns_subject: re.compile):
             return match.group(0)
     return None
 
+
 def hamming_distance_preset_length(string1, string2, barcode_length=35, cutoff=1):
     """
     Computes the hamming distance between two strings up until the string_distance is greater than cutoff and returns that value.

--- a/src/Utils/Record.py
+++ b/src/Utils/Record.py
@@ -36,7 +36,7 @@ class Record:
         self._run_record_through_checks(table=self.experimental)
 
     def unique_stock_biological_groups(self):
-        return list(self.stock['biological_group'].unique())
+        return list(self.stock["biological_group"].unique())
 
     def _run_record_through_checks(self, table):
         df_check_record = table.copy(deep=True)

--- a/tests/unit/test_Common.py
+++ b/tests/unit/test_Common.py
@@ -1,19 +1,17 @@
 import re
 from Utils.Common import find_subtring_match
 
+
 def test_find_subtring_match():
-	"""
-	python -m slipcover -m pytest -sv tests/unit/test_Common.py::test_find_subtring_match
-	"""
-	test_subject = [re.compile(subj) for subj in ['alex', 'kevin', 'chris', 'andrew']]
+    """
+    python -m slipcover -m pytest -sv tests/unit/test_Common.py::test_find_subtring_match
+    """
+    test_subject = [re.compile(subj) for subj in ["alex", "kevin", "chris", "andrew"]]
 
-	store_results = []
-	for test_query in ['alex.2', 'kevin_1', '__chrisxx_', 'andrewandrew']:
+    store_results = []
+    for test_query in ["alex.2", "kevin_1", "__chrisxx_", "andrewandrew"]:
+        store_results.append(find_subtring_match(test_query, test_subject))
 
-		store_results.append(find_subtring_match(test_query, test_subject))
+    assert len(store_results) == 4
 
-	assert len(store_results) == 4
-
-	assert store_results == ['alex', 'kevin', 'chris', 'andrew']
-
-
+    assert store_results == ["alex", "kevin", "chris", "andrew"]

--- a/tests/unit/test_Record.py
+++ b/tests/unit/test_Record.py
@@ -42,6 +42,7 @@ def test_load_records_pass(
 
             assert record.stock.equals(df_test_stock)
 
+
 def test_unique_stock_biological_groups_pass(
     mock_run_paths,
     stock_record,
@@ -64,7 +65,11 @@ def test_unique_stock_biological_groups_pass(
 
             record.load_stock_record()
 
-            assert record.unique_stock_biological_groups() == ['group1', 'group2', 'group3']
+            assert record.unique_stock_biological_groups() == [
+                "group1",
+                "group2",
+                "group3",
+            ]
 
 
 def test_update_records_pass(

--- a/tests/unit/test_ReportTable.py
+++ b/tests/unit/test_ReportTable.py
@@ -506,7 +506,7 @@ def test_pass(experimental_barcodes, experimental_record, standard_barcode_name_
     """
     python -m slipcover -m pytest -sv tests/unit/test_ReportTable.py::test_pass
     """
-    pd.set_option('display.max_columns', None)
+    pd.set_option("display.max_columns", None)
     print(experimental_barcodes)
 
     print(experimental_record)
@@ -682,49 +682,67 @@ def test_proportion_and_count_summary(
 
             with patch("Utils.ReportTable.glob") as mock_glob:
                 with patch("Utils.ReportTable.pd.read_csv") as mock_csv:
-                    with patch("Utils.ReportTable.os.path.basename") as mock_basename: #necessary for _read_in_experimental_samples
+                    with patch(
+                        "Utils.ReportTable.os.path.basename"
+                    ) as mock_basename:  # necessary for _read_in_experimental_samples
                         mock_glob.return_value = [
                             "bg1_plasma_7_not_specified_cdna_processed.csv",
                             "bg1_plasma_10_blood_vRNA_processed.csv",
                             "bg1_cd4_100_spleen_cdna_processed.csv",
-                            "bg2_plasma_0_not_specified_cdna_processed.csv"#,
-                            #"bg2_cd4_0_not_specified_not_specified_processed.csv",
+                            "bg2_plasma_0_not_specified_cdna_processed.csv"  # ,
+                            # "bg2_cd4_0_not_specified_not_specified_processed.csv",
                         ]
 
                         mock_basename.side_effect = [
                             "bg1_plasma_7_not_specified_cdna_processed.csv",
                             "bg1_plasma_10_blood_vRNA_processed.csv",
                             "bg1_cd4_100_spleen_cdna_processed.csv",
-                            "bg2_plasma_0_not_specified_cdna_processed.csv"#,
-                            #"bg2_cd4_0_not_specified_not_specified_processed.csv",
+                            "bg2_plasma_0_not_specified_cdna_processed.csv"  # ,
+                            # "bg2_cd4_0_not_specified_not_specified_processed.csv",
                         ]
 
                         mock_csv.side_effect = experimental_barcodes
 
-                        with patch.object(report_table.setup_manager.record, 'unique_stock_biological_groups', return_value=['CH505_V2', 'CH505_TF']):
-                            unique_stock_ids = report_table.setup_manager.record.unique_stock_biological_groups()
+                        with patch.object(
+                            report_table.setup_manager.record,
+                            "unique_stock_biological_groups",
+                            return_value=["CH505_V2", "CH505_TF"],
+                        ):
+                            unique_stock_ids = (
+                                report_table.setup_manager.record.unique_stock_biological_groups()
+                            )
 
                             report_table.proportion_and_count_summary()
 
-                            assert report_table.experimental_summary_table_counts.shape == (4, 11)
-                            assert report_table.experimental_summary_table_proportions.shape == (4, 11)
+                            assert (
+                                report_table.experimental_summary_table_counts.shape
+                                == (4, 11)
+                            )
+                            assert (
+                                report_table.experimental_summary_table_proportions.shape
+                                == (4, 11)
+                            )
 
-
-                            with patch.object(pd.DataFrame, 'to_csv') as mock_to_csv:
-
-                                with patch.object(report_table.setup_manager.run_paths, 'output', new = '/path/to/output'):
-
+                            with patch.object(pd.DataFrame, "to_csv") as mock_to_csv:
+                                with patch.object(
+                                    report_table.setup_manager.run_paths,
+                                    "output",
+                                    new="/path/to/output",
+                                ):
                                     report_table.write_proportion_and_count_summary()
 
                                     print(report_table.setup_manager.run_paths.output)
 
                                     # Check that to_csv was called with the correct arguments
-                                    mock_to_csv.assert_has_calls([
-                                        call('/path/to/output/experimental_summary_counts.csv', index=None),
-                                        call('/path/to/output/experimental_summary_proportion.csv', index=None)
-                                    ])
-
-
-
-
-
+                                    mock_to_csv.assert_has_calls(
+                                        [
+                                            call(
+                                                "/path/to/output/experimental_summary_counts.csv",
+                                                index=None,
+                                            ),
+                                            call(
+                                                "/path/to/output/experimental_summary_proportion.csv",
+                                                index=None,
+                                            ),
+                                        ]
+                                    )


### PR DESCRIPTION
There appear to be some python formatting errors in a43e8b5c9def7ef4824ba7e13865eb28602d8759. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.