### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/src/BartenderReport.py
+++ b/src/BartenderReport.py
@@ -110,11 +110,11 @@ def main():
 
         report_table.make_report_table_type_1_counts()
 
-        report_table.write_report_table_type_1_to_excel('count')
+        report_table.write_report_table_type_1_to_excel("count")
 
         report_table.transform_table_type_1_to_proportions()
 
-        report_table.write_report_table_type_1_to_excel('proportion')
+        report_table.write_report_table_type_1_to_excel("proportion")
 
     if args.experimental_summary_table:
         report_table = ReportTable(setup_manager=SetupManager(work_dir=args.run_dir))

--- a/src/Utils/ReportTable.py
+++ b/src/Utils/ReportTable.py
@@ -193,32 +193,38 @@ class ReportTable:
         """
 
         for count_table in self.type_1_experiment_table_count:
-            
             # copy count table, ignore metadata rows
-            df_counts = count_table.copy(deep = True).loc[9:]
+            df_counts = count_table.copy(deep=True).loc[9:]
 
             # summed totals
-            column_sums = df_counts.loc[:, ~df_counts.columns.isin(['standard_barcode_name', 'barcode'])].sum()
+            column_sums = df_counts.loc[
+                :, ~df_counts.columns.isin(["standard_barcode_name", "barcode"])
+            ].sum()
             # column_sums = df_counts.iloc[:, 2:].sum()
 
             # each barcode divided by respective sumemd total
-            df_proportion = df_counts.loc[:, ~df_counts.columns.isin(['standard_barcode_name', 'barcode'])].div(column_sums, axis=1)
+            df_proportion = df_counts.loc[
+                :, ~df_counts.columns.isin(["standard_barcode_name", "barcode"])
+            ].div(column_sums, axis=1)
 
             # add the initial two columns back to the dataframe
-            df_proportion = pd.concat([df_counts[['standard_barcode_name', 'barcode']], df_proportion], axis=1)
+            df_proportion = pd.concat(
+                [df_counts[["standard_barcode_name", "barcode"]], df_proportion], axis=1
+            )
 
-            # get the metadata rows 
+            # get the metadata rows
             df_metadata = count_table.iloc[:9]
 
             # add the metadata back to the dataframe
-            df_combined = pd.concat([df_metadata, df_proportion], axis = 0, ignore_index = True)
+            df_combined = pd.concat(
+                [df_metadata, df_proportion], axis=0, ignore_index=True
+            )
 
             self.type_1_experiment_table_proportion.append(df_combined)
 
-
     def make_report_table_type_1_counts(self):
         """
-        Assigns self.type_1_experiment_table a list. Each item is a pandas dataframe 
+        Assigns self.type_1_experiment_table a list. Each item is a pandas dataframe
         in the type_1 format
         """
         pd.options.mode.chained_assignment = None
@@ -342,15 +348,21 @@ class ReportTable:
         Writes either count or proportion type 1 tables to excel
         """
         table_type = {
-            'count': {'filename': 'barcode_report_table_type_1_count.xlsx', 'data_list': self.type_1_experiment_table_count},
-            'proportion': {'filename': 'barcode_report_table_type_1_proportion.xlsx', 'data_list': self.type_1_experiment_table_proportion},
+            "count": {
+                "filename": "barcode_report_table_type_1_count.xlsx",
+                "data_list": self.type_1_experiment_table_count,
+            },
+            "proportion": {
+                "filename": "barcode_report_table_type_1_proportion.xlsx",
+                "data_list": self.type_1_experiment_table_proportion,
+            },
         }
 
         try:
             os.remove(
                 pjoin(
                     self.setup_manager.run_paths.output,
-                    table_type[table_to_process]['filename'],
+                    table_type[table_to_process]["filename"],
                 )
             )
         except:
@@ -358,10 +370,13 @@ class ReportTable:
 
         with pd.ExcelWriter(
             pjoin(
-                self.setup_manager.run_paths.output, table_type[table_to_process]['filename']
+                self.setup_manager.run_paths.output,
+                table_type[table_to_process]["filename"],
             )
         ) as writer:
-            for table in table_type[table_to_process]['data_list']: #self.type_1_experiment_table:
+            for table in table_type[table_to_process][
+                "data_list"
+            ]:  # self.type_1_experiment_table:
                 biological_group = table.iloc[0, 0]
 
                 table.to_excel(

--- a/tests/unit/test_ReportTable.py
+++ b/tests/unit/test_ReportTable.py
@@ -654,18 +654,27 @@ def test_make_report_table_type_1(
 
                         assert len(report_table.type_1_experiment_table_count) == 2
 
-                        assert report_table.type_1_experiment_table_count[0].shape == (15, 5)
+                        assert report_table.type_1_experiment_table_count[0].shape == (
+                            15,
+                            5,
+                        )
 
-                        assert report_table.type_1_experiment_table_count[1].shape == (18, 4)
-
+                        assert report_table.type_1_experiment_table_count[1].shape == (
+                            18,
+                            4,
+                        )
 
                         report_table.transform_table_type_1_to_proportions()
 
                         assert len(report_table.type_1_experiment_table_proportion) == 2
 
-                        assert report_table.type_1_experiment_table_proportion[0].shape == (15, 5)
+                        assert report_table.type_1_experiment_table_proportion[
+                            0
+                        ].shape == (15, 5)
 
-                        assert report_table.type_1_experiment_table_proportion[1].shape == (18, 4)
+                        assert report_table.type_1_experiment_table_proportion[
+                            1
+                        ].shape == (18, 4)
 
 
 def test_proportion_and_count_summary(
@@ -755,10 +764,18 @@ def test_proportion_and_count_summary(
                                             ),
                                         ]
                                     )
-                                    mock_to_csv.assert_has_calls([
-                                        call('/path/to/output/experimental_summary_counts.csv', index=None),
-                                        call('/path/to/output/experimental_summary_proportion.csv', index=None)
-                                    ])
+                                    mock_to_csv.assert_has_calls(
+                                        [
+                                            call(
+                                                "/path/to/output/experimental_summary_counts.csv",
+                                                index=None,
+                                            ),
+                                            call(
+                                                "/path/to/output/experimental_summary_proportion.csv",
+                                                index=None,
+                                            ),
+                                        ]
+                                    )
 
 
 @pytest.fixture
@@ -768,13 +785,17 @@ def setup_manager_mock():
     mock.run_paths.output = "/fake/output/path"
     return mock
 
+
 @pytest.fixture
 def report_table_instance(setup_manager_mock):
     """Instance of ReportTable with a mocked SetupManager."""
     return ReportTable(setup_manager_mock)
 
+
 @patch("Utils.ReportTable.pd.ExcelWriter")
-def test_write_report_table_type_1_to_excel_count(mock_excel_writer, report_table_instance):
+def test_write_report_table_type_1_to_excel_count(
+    mock_excel_writer, report_table_instance
+):
     """
     python -m slipcover -m pytest -sv tests/unit/test_ReportTable.py::test_write_report_table_type_1_to_excel_count
     """
@@ -782,18 +803,23 @@ def test_write_report_table_type_1_to_excel_count(mock_excel_writer, report_tabl
     # Mocking data for type_1_experiment_table_count
     mock_table = MagicMock(spec=pd.DataFrame)
     report_table_instance.type_1_experiment_table_count = [mock_table]
-    
+
     # Call the method
     report_table_instance.write_report_table_type_1_to_excel("count")
-    
+
     # Ensure pd.ExcelWriter is called with the correct file path
-    mock_excel_writer.assert_called_once_with("/fake/output/path/barcode_report_table_type_1_count.xlsx")
-    
+    mock_excel_writer.assert_called_once_with(
+        "/fake/output/path/barcode_report_table_type_1_count.xlsx"
+    )
+
     # Ensure the `to_excel` method is called on the DataFrame
     mock_table.to_excel.assert_called_once()
 
+
 @patch("Utils.ReportTable.pd.ExcelWriter")
-def test_write_report_table_type_1_to_excel_proportion(mock_excel_writer, report_table_instance):
+def test_write_report_table_type_1_to_excel_proportion(
+    mock_excel_writer, report_table_instance
+):
     """
     python -m slipcover -m pytest -sv tests/unit/test_ReportTable.py::test_write_report_table_type_1_to_excel_proportion
     """
@@ -801,13 +827,14 @@ def test_write_report_table_type_1_to_excel_proportion(mock_excel_writer, report
     # Mocking data for type_1_experiment_table_count
     mock_table = MagicMock(spec=pd.DataFrame)
     report_table_instance.type_1_experiment_table_proportion = [mock_table]
-    
+
     # Call the method
     report_table_instance.write_report_table_type_1_to_excel("proportion")
-    
+
     # Ensure pd.ExcelWriter is called with the correct file path
-    mock_excel_writer.assert_called_once_with("/fake/output/path/barcode_report_table_type_1_proportion.xlsx")
-    
+    mock_excel_writer.assert_called_once_with(
+        "/fake/output/path/barcode_report_table_type_1_proportion.xlsx"
+    )
+
     # Ensure the `to_excel` method is called on the DataFrame
     mock_table.to_excel.assert_called_once()
-


### PR DESCRIPTION
There appear to be some python formatting errors in dfd0bbd18d53b103e285dad5eb6b47113608b461. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.